### PR TITLE
Add Spring Doc dependency for OpenAPI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- Add Spring Doc dependency -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Introduces the `springdoc-openapi-starter-webmvc-ui` dependency to enable OpenAPI documentation generation for the project. This addition facilitates better API documentation and improves developer collaboration.